### PR TITLE
Use .Login if .Name isn't defined

### DIFF
--- a/githubdigest/report.go
+++ b/githubdigest/report.go
@@ -31,7 +31,6 @@ func GenerateReport(c *cli.Context, stats *GithubDigest) (*string, error) {
 	return &report, nil
 }
 
-
 func SendReport(c *cli.Context, report string) error {
 	mailgunApiKey := c.String("mailgun")
 	emailTo := c.String("mail-to")
@@ -57,5 +56,3 @@ func SendReport(c *cli.Context, report string) error {
 	}
 	return nil
 }
-
-


### PR DESCRIPTION
In practice, .Name doesn't seem to be filled by these queries.
We'll have to lookup users by their login/id in order to provide pretty
names: that's too complex to sneak in.
